### PR TITLE
chore(devfile) use ubi-latest tag for UDI

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,5 +4,5 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-3d26fec
+      image: quay.io/devfile/universal-developer-image:ubi8-latest
       memoryLimit: 3Gi


### PR DESCRIPTION
chore(devfile) use ubi-latest tag for UDI

Related issue: https://github.com/eclipse/che/issues/21979